### PR TITLE
Restore skill bars and improve skills presentation

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -818,24 +818,12 @@ properly.
   color: #111;
 }
 
-/* Modern skills layout: keep it minimal and high-contrast */
-.modern-skills {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 14px 28px;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-.modern-skills li {
-  background: rgba(0,0,0,0.05);
-  color: #111;
-  padding: 8px 12px;
-  border-radius: 6px;
-  font-weight: 600;
-  font-family: 'opensans-bold', sans-serif;
-  box-shadow: none;
-}
+/* Skill bars: concise, high-contrast */
+.skill-list { display: flex; flex-direction: column; gap: 12px; }
+.skill { display:flex; flex-direction:column; gap:6px; }
+.skill-label { font-weight:700; color:#0b0b0b; font-family:'opensans-bold',sans-serif; }
+.skill-bar { background: rgba(0,0,0,0.08); height:10px; border-radius:6px; overflow:hidden; }
+.skill-fill { height:100%; background: linear-gradient(90deg,#2b8cff,#0066ff); border-radius:6px; }
 
 /* Ensure strong contrast for skills and content below resume */
 #skills, #certificates, #testimonials, #keys, #contact, footer {

--- a/index.html
+++ b/index.html
@@ -219,15 +219,15 @@
 
     <div class="nine columns main-col">
       <div class="bars">
-        <ul class="skills modern-skills">
-          <li><em>Claude</em></li>
-          <li><em>GitHub Actions</em></li>
-          <li><em>OpenTelemetry</em></li>
-          <li><em>Kubernetes</em></li>
-          <li><em>GCP</em></li>
-          <li><em>AWS</em></li>
-          <li><em>Golang</em></li>
-        </ul>
+        <div class="skill-list">
+          <div class="skill"><span class="skill-label">Kubernetes</span><div class="skill-bar"><div class="skill-fill" style="width:90%"></div></div></div>
+          <div class="skill"><span class="skill-label">GitHub Actions</span><div class="skill-bar"><div class="skill-fill" style="width:85%"></div></div></div>
+          <div class="skill"><span class="skill-label">AWS</span><div class="skill-bar"><div class="skill-fill" style="width:85%"></div></div></div>
+          <div class="skill"><span class="skill-label">GCP</span><div class="skill-bar"><div class="skill-fill" style="width:80%"></div></div></div>
+          <div class="skill"><span class="skill-label">OpenTelemetry</span><div class="skill-bar"><div class="skill-fill" style="width:80%"></div></div></div>
+          <div class="skill"><span class="skill-label">Golang</span><div class="skill-bar"><div class="skill-fill" style="width:80%"></div></div></div>
+          <div class="skill"><span class="skill-label">Claude</span><div class="skill-bar"><div class="skill-fill" style="width:70%"></div></div></div>
+        </div>
       </div><!-- end skill-bars -->
     </div><!-- main-col end -->
   </div><!-- End skills -->


### PR DESCRIPTION
Restore skill bars (visual proficiency) and display concise modern skills for SRE/observability: Claude, GitHub Actions, OpenTelemetry, Kubernetes, GCP, AWS, Golang. Added compact, high-contrast bar styles. Kept layout minimal as requested.