### PR TITLE
Restore CSS and update skills

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -817,28 +817,3 @@ properly.
 #about h2, #resume h2, #certificates h2, #testimonials h2, #keys h2, #contact h2 {
   color: #111;
 }
-
-/* Skill bars: concise, high-contrast */
-.skill-list { display: flex; flex-direction: column; gap: 12px; }
-.skill { display:flex; flex-direction:column; gap:6px; }
-.skill-label { font-weight:700; color:#0b0b0b; font-family:'opensans-bold',sans-serif; }
-.skill-bar { background: rgba(0,0,0,0.08); height:10px; border-radius:6px; overflow:hidden; }
-.skill-fill { height:100%; background: linear-gradient(90deg,#2b8cff,#0066ff); border-radius:6px; }
-
-/* Ensure strong contrast for skills and content below resume */
-#skills, #certificates, #testimonials, #keys, #contact, footer {
-  color: #111 !important;
-}
-#skills p, #certificates p, #testimonials p, #keys p, #contact p, footer p {
-  color: #222 !important;
-}
-
-/* Slightly emphasize headings */
-#skills h2, #certificates h2, #testimonials h2, #keys h2, #contact h2 {
-  color: #000 !important;
-}
-
-/* Make resume area text easier to read */
-.row.education .main-col, .row.work .main-col {
-  color: #222;
-}

--- a/index.html
+++ b/index.html
@@ -212,25 +212,27 @@
   <!-- Skills
       =============================================== -->
 
-  <section id="skills">  <section id="skills">  <section id="skills"><div class="row skill">
+  <section id="skills">
+  <div class="row skill">
     <div class="three columns header-col">
       <h2><span>Skills</span></h2>
     </div>
 
     <div class="nine columns main-col">
       <div class="bars">
-        <div class="skill-list">
-          <div class="skill"><span class="skill-label">Kubernetes</span><div class="skill-bar"><div class="skill-fill" style="width:90%"></div></div></div>
-          <div class="skill"><span class="skill-label">GitHub Actions</span><div class="skill-bar"><div class="skill-fill" style="width:85%"></div></div></div>
-          <div class="skill"><span class="skill-label">AWS</span><div class="skill-bar"><div class="skill-fill" style="width:85%"></div></div></div>
-          <div class="skill"><span class="skill-label">GCP</span><div class="skill-bar"><div class="skill-fill" style="width:80%"></div></div></div>
-          <div class="skill"><span class="skill-label">OpenTelemetry</span><div class="skill-bar"><div class="skill-fill" style="width:80%"></div></div></div>
-          <div class="skill"><span class="skill-label">Golang</span><div class="skill-bar"><div class="skill-fill" style="width:80%"></div></div></div>
-          <div class="skill"><span class="skill-label">Claude</span><div class="skill-bar"><div class="skill-fill" style="width:70%"></div></div></div>
-        </div>
+        <ul class="skills">
+          <li><em>Claude</em></li>
+          <li><em>GitHub Actions</em></li>
+          <li><em>OpenTelemetry</em></li>
+          <li><em>Kubernetes</em></li>
+          <li><em>GCP</em></li>
+          <li><em>AWS</em></li>
+          <li><em>Golang</em></li>
+        </ul>
       </div><!-- end skill-bars -->
     </div><!-- main-col end -->
   </div><!-- End skills -->
+  </section>
   </section>
   <hr>
   <!-- Resume Section End-->


### PR DESCRIPTION
Restore css/default.css to pre-change state and replace only the Skills section with a concise modern list: Claude, GitHub Actions, OpenTelemetry, Kubernetes, GCP, AWS, Golang. This reverts visual regressions while updating content.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>